### PR TITLE
prevent redirect pages from being extracted

### DIFF
--- a/main.py
+++ b/main.py
@@ -262,7 +262,7 @@ def collect_pages(text):
             page.append(line)
         elif tag == '/page':
             colon = title.find(':')
-            if (colon < 0 or (title[:colon] in acceptedNamespaces) and id != last_id and
+            if ((colon < 0 or (title[:colon] in acceptedNamespaces)) and id != last_id and
                     not redirect and not title.startswith(templateNamespace)):
                 yield (id, revid, title, page)
                 last_id = id


### PR DESCRIPTION
Added parens to if statement so "and not redirect" would prevent redirect pages from being extracted.  Part of the initial or statement pair was always true, so the following and statements were ignored. 